### PR TITLE
fix(core): use AWS_S3_ASSETS_BUCKET for asset upload/delete

### DIFF
--- a/apps/core/src/core/endpoints/v2/asset.py
+++ b/apps/core/src/core/endpoints/v2/asset.py
@@ -135,7 +135,7 @@ async def upload_asset(
 
     s3_service.upload_file(
         file_content=io.BytesIO(file_content),
-        bucket_name=settings.S3_BUCKET_NAME,
+        bucket_name=settings.AWS_S3_ASSETS_BUCKET,
         s3_key=s3_key,
         content_type=actual_mime_type,
     )
@@ -250,7 +250,7 @@ async def delete_asset(
         )
 
     # Delete from S3
-    s3_service.delete_file(bucket_name=settings.S3_BUCKET_NAME, s3_key=asset.s3_key)
+    s3_service.delete_file(bucket_name=settings.AWS_S3_ASSETS_BUCKET, s3_key=asset.s3_key)
 
     # Delete from DB
     await async_session.delete(asset)


### PR DESCRIPTION
S3_BUCKET_NAME is for layer/tile data; AWS_S3_ASSETS_BUCKET is the bucket that assets.plan4better.de serves from. Using the wrong bucket caused 403s in production.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Related Issue
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
<!--- Put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->

<!--- Attribution: https://github.com/stevemao/github-issue-templates -->
