### PR TITLE
chore: remove apps/accounts private submodule

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -91,6 +91,8 @@ jobs:
           echo "SAFE_IMAGE=$safe_image" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
+        with:
+          submodules: false
 
       - name: 🐹 Set up QEMU for cross-arch builds
         uses: docker/setup-qemu-action@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "apps/accounts"]
-	path = apps/accounts
-	url = git@github.com:EPajares/goat-accounts.git


### PR DESCRIPTION
The accounts repo is private and only needed occasionally for local development. Removing the submodule prevents CI Docker builds from failing when trying to clone the inaccessible SSH URL.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Related Issue
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
<!--- Put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->

<!--- Attribution: https://github.com/stevemao/github-issue-templates -->
