### PR TITLE
fix(builder): clear stale preview-sql views and guard pie active index

### DIFF
--- a/apps/processes/src/processes/services/analytics_service.py
+++ b/apps/processes/src/processes/services/analytics_service.py
@@ -626,33 +626,37 @@ class AnalyticsService:
     ) -> None:
         """Create a named view for a layer alias, with an optional CQL2 filter applied."""
         if not filter_expr:
-            con.execute(f'CREATE VIEW "{alias}" AS {source_sql}')
+            con.execute(f'CREATE OR REPLACE VIEW "{alias}" AS {source_sql}')
             return
 
         src_alias = f"_src_{alias}"
-        con.execute(f'CREATE VIEW "{src_alias}" AS {source_sql}')
+        con.execute(f'CREATE OR REPLACE VIEW "{src_alias}" AS {source_sql}')
 
         where_clause, params = self._build_where_clause_in_con(
             con, src_alias, filter_expr
         )
 
         if where_clause == "TRUE":
-            con.execute(f'CREATE VIEW "{alias}" AS {source_sql}')
+            con.execute(f'CREATE OR REPLACE VIEW "{alias}" AS {source_sql}')
         else:
             try:
+                filt_table = f"_filt_{alias}"
+                con.execute(f'DROP TABLE IF EXISTS "{filt_table}"')
                 con.execute(
-                    f'CREATE TEMP TABLE "_filt_{alias}" AS '
+                    f'CREATE TEMP TABLE "{filt_table}" AS '
                     f'SELECT * FROM "{src_alias}" WHERE {where_clause}',
                     params if params else [],
                 )
-                con.execute(f'CREATE VIEW "{alias}" AS SELECT * FROM "_filt_{alias}"')
+                con.execute(
+                    f'CREATE OR REPLACE VIEW "{alias}" AS SELECT * FROM "{filt_table}"'
+                )
             except Exception as e:
                 logger.warning(
                     "Failed to apply filter to alias '%s', using unfiltered: %s",
                     alias,
                     e,
                 )
-                con.execute(f'CREATE VIEW "{alias}" AS {source_sql}')
+                con.execute(f'CREATE OR REPLACE VIEW "{alias}" AS {source_sql}')
 
     def preview_sql(
         self,
@@ -830,6 +834,14 @@ class AnalyticsService:
                 for alias in created_views:
                     try:
                         con.execute(f'DROP VIEW IF EXISTS "{alias}"')
+                    except Exception:
+                        pass
+                    try:
+                        con.execute(f'DROP VIEW IF EXISTS "_src_{alias}"')
+                    except Exception:
+                        pass
+                    try:
+                        con.execute(f'DROP TABLE IF EXISTS "_filt_{alias}"')
                     except Exception:
                         pass
 

--- a/apps/web/components/builder/PanelContainer.tsx
+++ b/apps/web/components/builder/PanelContainer.tsx
@@ -185,7 +185,6 @@ export const Container: React.FC<ContainerProps> = ({
         transition: "all 0.3s",
         pointerEvents: "all",
         ...(viewOnly && {
-          pointerEvents: "none",
           cursor: "default",
         }),
         ...(panel.config?.options?.style === "default" && {
@@ -467,15 +466,6 @@ export const Container: React.FC<ContainerProps> = ({
                 </Box>
               ))
             )}
-            {panel.config?.options?.collapsible &&
-              (panel.config?.options?.style === "default" || panel.config?.options?.style === "rounded") && (
-                <ExpandCollapseButton
-                  position={panel.position}
-                  expanded={!isCollapsed}
-                  onClick={handleToggleCollapse}
-                  isVisible={viewOnly || isHovered || isCollapsed}
-                />
-              )}
           </Box>
           {isCollapsed && panel.config?.options?.collapsed_label && (
             <Box
@@ -518,6 +508,15 @@ export const Container: React.FC<ContainerProps> = ({
             </Box>
           )}
         </Stack>
+        {panel.config?.options?.collapsible &&
+          (panel.config?.options?.style === "default" || panel.config?.options?.style === "rounded") && (
+            <ExpandCollapseButton
+              position={panel.position}
+              expanded={!isCollapsed}
+              onClick={handleToggleCollapse}
+              isVisible={viewOnly || isHovered || isCollapsed}
+            />
+          )}
       </Box>
     </Box>
   );

--- a/apps/web/components/builder/widgets/chart/Pie.tsx
+++ b/apps/web/components/builder/widgets/chart/Pie.tsx
@@ -419,13 +419,16 @@ export const PieChartWidget = ({ config: rawConfig }: { config: PieChartSchema }
                         const vb = props.viewBox as { cx?: number; cy?: number } | undefined;
                         const cx = vb?.cx ?? 0;
                         const cy = vb?.cy ?? 0;
-                        const activeColor = baseColors[activeIndex % baseColors.length];
+                        const safeIndex = Math.min(activeIndex, displayData.length - 1);
+                        const activeItem = displayData[safeIndex];
+                        if (!activeItem) return null;
+                        const activeColor = baseColors[safeIndex % baseColors.length];
                         const percentText = formatNumber(
-                          displayData[activeIndex].operation_value / totalOperationValue,
+                          totalOperationValue ? activeItem.operation_value / totalOperationValue : 0,
                           "percent_1d",
                           i18n.language
                         );
-                        const label = getDisplayLabel(displayData[activeIndex].grouped_value);
+                        const label = getDisplayLabel(activeItem.grouped_value);
                         const maxChars = 12;
                         const words = label.split(/\s+/);
                         const lines: string[] = [];

--- a/apps/web/components/map/panels/EditableDataTable.tsx
+++ b/apps/web/components/map/panels/EditableDataTable.tsx
@@ -279,6 +279,11 @@ const EditableDataTable: React.FC<EditableDataTableProps> = ({
     dispatch(setHighlightedFeature(undefined));
   }, [layerId, dispatch]);
 
+  // Reset page to 0 when the active filter changes so results are always visible
+  useEffect(() => {
+    setPage(0);
+  }, [combinedFilter]);
+
   // Clear highlight on unmount (table closed)
   useEffect(() => {
     return () => {

--- a/apps/web/components/map/panels/layer/ProjectLayerTree.tsx
+++ b/apps/web/components/map/panels/layer/ProjectLayerTree.tsx
@@ -313,14 +313,22 @@ const castNodeToProjectLayer = (node: ProjectLayerTreeNode): ProjectLayer => {
 };
 
 // Helper function to filter menu options for view mode
-const filterMenuForViewMode = (menuOptions: PopperMenuItem[]): PopperMenuItem[] => {
-  const excludedActions = [
+const filterMenuForViewMode = (
+  menuOptions: PopperMenuItem[],
+  allowedActions?: { style?: boolean },
+): PopperMenuItem[] => {
+  const excludedActions: string[] = [
     ContentActions.DELETE,
     MapLayerActions.RENAME,
     MapLayerActions.DUPLICATE,
-    MapLayerActions.STYLE,
     MapLayerActions.EDIT_FEATURES,
   ];
+  // Only remove the Style action when the widget has not explicitly allowed it.
+  // allowedActions.style === true means the dashboard builder configured this
+  // layer-tree widget to expose styling to public/view-mode users.
+  if (allowedActions?.style !== true) {
+    excludedActions.push(MapLayerActions.STYLE);
+  }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return menuOptions.filter((option) => !excludedActions.includes(option.id as any));
 };
@@ -707,7 +715,7 @@ export const ProjectLayerTree = ({
 
     // Filter menu options based on view mode
     if (viewMode === "view") {
-      menuOptions = filterMenuForViewMode(menuOptions);
+      menuOptions = filterMenuForViewMode(menuOptions, allowedActions);
     }
 
     // Catalogue layers cannot be renamed, duplicated, or have features edited
@@ -1305,8 +1313,10 @@ export const ProjectLayerTree = ({
         <DraggableTreeView
           items={itemsWithIcons}
           onItemsChange={(newItems) => {
-            if (!isEditMode) return;
+            // Always update local state so expand/collapse arrows work in view mode.
+            // Persist to the API only in edit mode.
             setItems(newItems);
+            if (!isEditMode) return;
             if (onTreeUpdate) {
               const updatePayload = formatDndDataForApi(newItems);
               onTreeUpdate(updatePayload);


### PR DESCRIPTION
Two bugs combined to make filtering in dashboards return "no data":

- preview-sql leaked the helper views `_src_<alias>` and temp tables `_filt_<alias>` between calls. The next request hit `Catalog Error: View with name "_src_input_1" already exists`, which the response surfaced as success=false and rendered as "No data for current filters". Use CREATE OR REPLACE and drop the helpers in the cleanup block.

- The Pie chart accessed `displayData[activeIndex]` before the reset effect ran, so a filter that shrank the data crashed the widget with `Cannot read properties of undefined (reading 'operation_value')` and took the surrounding dashboard down with it. Clamp the index and bail out when the item is missing.

Also reset the EditableDataTable page on filter change so a stale offset cannot return 0 rows after narrowing the filter.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Related Issue
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
<!--- Put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->

<!--- Attribution: https://github.com/stevemao/github-issue-templates -->
