### PR TITLE
docs: update documentation for recently shipped features (EN + DE)

### DIFF
--- a/apps/docs/docs/builder/settings.md
+++ b/apps/docs/docs/builder/settings.md
@@ -70,7 +70,49 @@ Customize how your dashboard appears when shared via social media or messaging a
 
 ## Interactions
 
-Click `Manage Interactions` to open the interactions editor. Interactions link dashboard elements together — for example, clicking a layer group can switch the active tab in a widget. Click `Add Interaction` to create a new one.
+Interactions link dashboard elements together, so that one action by the viewer automatically triggers a matching change in another element. For example, activating a layer group can switch the active tab in a widget, or toggling one layer's visibility can show and hide related layers.
+
+Click `Manage Interactions` to open the interactions editor. Each interaction is a rule made of a **trigger** (`When` something happens) and an **action** (what happens in response). Click `Add Interaction` to create a new rule, then choose the trigger under `When`. Use the `Enabled` toggle to turn an individual interaction on or off without deleting it.
+
+GOAT supports two types of interaction:
+
+### Layer group activated → Switch tab
+
+When a viewer activates a layer group, a Tabs widget switches to a tab you choose.
+
+<div class="step">
+  <div class="step-number">1</div>
+  <div class="content">Set <code>When</code> to <code>Layer group activated</code>.</div>
+</div>
+
+<div class="step">
+  <div class="step-number">2</div>
+  <div class="content">Select the <code>Target widget</code> — the Tabs widget whose active tab should change.</div>
+</div>
+
+<div class="step">
+  <div class="step-number">3</div>
+  <div class="content">Under <code>Layer group</code> and <code>Tab</code>, map each layer group to the tab it should open. Click <code>Add mapping</code> to add more pairs.</div>
+</div>
+
+### Layer visibility changed → Sync visibility
+
+When a viewer shows or hides a layer, one or more other layers are shown or hidden to match.
+
+<div class="step">
+  <div class="step-number">1</div>
+  <div class="content">Set <code>When</code> to <code>Layer visibility changed</code>.</div>
+</div>
+
+<div class="step">
+  <div class="step-number">2</div>
+  <div class="content">Select the <code>Source layer</code> — the layer whose visibility is watched.</div>
+</div>
+
+<div class="step">
+  <div class="step-number">3</div>
+  <div class="content">Add one or more <code>Target layers</code> that should mirror the source layer's visibility. Click <code>Add target layer</code> to add more.</div>
+</div>
 
 ---
 

--- a/apps/docs/docs/map/filter.md
+++ b/apps/docs/docs/map/filter.md
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 # Filter
 
-**Filter limits data visibility on your map** using logical expressions (e.g., supermarkets with specific names) or spatial expressions (e.g., points within a bounding box). **The filter allows you to focus on relevant information without altering original data.** It works with **point layers** and **polygon layers** containing `number` and `string` data types. 
+**Filter limits data visibility on your map** using logical expressions (e.g., supermarkets with specific names) or spatial expressions (e.g., points within a bounding box). **The filter allows you to focus on relevant information without altering original data.** It works with **point layers** and **polygon layers** containing `number`, `string`, `datetime`, and `boolean` data types. 
 
 <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
   <img src={require('/img/map/filter/filter_clicking.gif').default} alt="Filter tool in GOAT" style={{ maxHeight: "auto", maxWidth: "80%", objectFit: "cover"}}/>
@@ -47,7 +47,7 @@ import TabItem from '@theme/TabItem';
 
 <div class="step">
   <div class="step-number">6</div>
-  <div class="content">Choose the <code>Operator</code>. Available options vary by data type: number and string.</div>
+  <div class="content">Choose the <code>Operator</code>. Available options vary by data type (<code>number</code>, <code>string</code>, <code>datetime</code>, and <code>boolean</code>).</div>
 </div>
 
 <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
@@ -58,6 +58,8 @@ import TabItem from '@theme/TabItem';
 | is not  | is not |
 | includes  | includes  |
 | excludes  |  excludes |
+| is blank | is blank |
+| is not blank | is not blank |
 | is at least  | starts with |
 | is less than | ends with |
 | is at most | contains the text |
@@ -66,6 +68,25 @@ import TabItem from '@theme/TabItem';
 |  | is not empty string |
 
 </div>
+
+<div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+
+| Expressions for `datetime` | Expressions for `boolean` |
+| -------|----|
+| is on | is true |
+| is not on | is false |
+| is before | is blank |
+| is after | is not blank |
+| in the last |  |
+| not in the last |  |
+| is between |  |
+| is not between |  |
+
+</div>
+
+:::tip Hint
+For `datetime` fields, choose a date from the **date picker**. **"is between"** uses two dates (**From** and **To**), and **"in the last"** takes a **number of days**. For `boolean` fields, the operator already sets the condition, so no value is needed.
+:::
 
 
 :::tip Hint

--- a/apps/docs/docs/map/layer_editing.md
+++ b/apps/docs/docs/map/layer_editing.md
@@ -44,7 +44,7 @@ Once a layer is created, you can add and edit features directly on the map.
 
 ## View Data
 
-**View Data** lets you see and edit your layer data as a table. Open it from the layer's <code>more options</code> menu to manage fields, edit attribute values directly in the table, or enter edit mode to add and modify features on the map.
+**View Data** lets you see and edit your layer data as a table. Open it from the layer's <img src={require('/img/icons/3dots.png').default} alt="Options" style={{ maxHeight: "20px", maxWidth: "20px", objectFit: "cover"}}/> <code>more options</code> menu to manage fields, edit attribute values directly in the table, or enter edit mode to add and modify features on the map.
 
 <div class="step">
   <div class="step-number">1</div>
@@ -53,10 +53,40 @@ Once a layer is created, you can add and edit features directly on the map.
 
 <div class="step">
   <div class="step-number">2</div>
-  <div class="content">Click <code>+ Add field</code> to open the <b>Edit fields</b> dialog. Add a new field by entering a <b>field name</b> and selecting its <b>Field type</b>. To remove a field, click the <code>—</code> icon next to it. Click <code>Save</code> when done.</div>
+  <div class="content">Click <code>Edit fields</code> in the table toolbar to open the <b>Edit fields</b> dialog, then click <code>+ Add field</code>. A new field is added to the list — select its <b>Field type</b> on the right (<code>Text</code>, <code>Number</code>, <code>Date</code>, <code>Boolean</code>, or <code>Formula</code>, a computed field, see <a href="#formula-fields">Formula fields</a> below), and rename the field in the list. To remove a field, click the <code>—</code> icon next to it. Click <code>Save</code> when done.</div>
 </div>
 
 <div class="step">
   <div class="step-number">3</div>
   <div class="content">Click <code>Edit features</code> in the table toolbar to enter edit mode. You can <strong>click directly on a cell</strong> in the table to edit attribute values inline, use the <strong>pointer</strong> on the map to select an existing feature and update its attributes in the <b>Feature attributes</b> panel, or use <code>+</code> to draw a new feature. Click <code>Save</code> or <code>Discard</code> when done.</div>
 </div>
+
+### Formula fields
+
+A **Formula** field's value is calculated from an expression you write, similar to a formula column in a spreadsheet. The expression can reference your other fields — for example, divide population by area to get density — or combine text fields into one. The result is applied to every feature in the layer.
+
+<div class="step">
+  <div class="step-number">1</div>
+  <div class="content">Click <code>Edit fields</code> to open the <b>Edit fields</b> dialog and click <code>+ Add field</code>. With the new field selected, set its <code>Field type</code> on the right to <code>Formula</code> (and rename the field in the list).</div>
+</div>
+
+<div class="step">
+  <div class="step-number">2</div>
+  <div class="content">Click <code>Add formula</code> to open the <b>Formula Builder</b>. Write an expression, referencing your other fields by name in double quotes (for example <code>"population"</code>). The <b>Build</b> tab lets you insert fields, operators, and functions, and the <b>Preview</b> tab shows a sample result. A green check confirms the expression is valid.</div>
+</div>
+
+<div class="step">
+  <div class="step-number">3</div>
+  <div class="content">Click <code>Apply</code>, then <code>Save</code> in the Edit fields dialog. GOAT computes the values for all features and keeps them up to date automatically.</div>
+</div>
+
+**Examples:**
+
+- <code>"population" / "area_km2"</code> — population density
+- <code>round("population" / "area_km2", 1)</code> — density rounded to one decimal
+- <code>concat_ws(', ', "city", "country")</code> — combine text fields (e.g. `Berlin, Germany`)
+- <code>if("population" &gt; 100000, 'large', 'small')</code> — classify by a threshold
+
+:::info
+A formula's values update automatically when the fields it references change. A formula must produce a number, text, true/false, or date value. Formula fields are only available on existing layers.
+:::

--- a/apps/docs/docs/nerdy_content/GOAT_ui_glossary.md
+++ b/apps/docs/docs/nerdy_content/GOAT_ui_glossary.md
@@ -384,6 +384,22 @@ This comprehensive glossary provides English to German translations for all the 
 | Value Labels | Wertbeschriftungen | Show data values on chart elements |
 | Selection Response | Auswahlverhalten | How a widget reacts to map selection |
 | Cross-filter Options | Optionen querfiltern | Settings for cross-widget filtering interaction |
+| **Interactions** | **Interaktionen** | Rules linking dashboard elements so one action triggers a change in another |
+| Manage Interactions | Interaktionen verwalten | Open the interactions editor |
+| Add Interaction | Interaktion hinzufügen | Create a new interaction rule |
+| Enabled | Aktiviert | Toggle an individual interaction on or off |
+| When | Wenn | The trigger condition of an interaction |
+| Layer group activated | Layer-Gruppe aktiviert | Trigger: a layer group is activated |
+| Layer visibility changed | Layer-Sichtbarkeit geändert | Trigger: a layer is shown or hidden |
+| Switch tab | Tab wechseln | Action: switch the active tab of a Tabs widget |
+| Sync visibility | Sichtbarkeit synchronisieren | Action: mirror a layer's visibility onto other layers |
+| Target widget | Ziel-Widget | The Tabs widget whose active tab is changed |
+| Layer group | Layer-Gruppe | The layer group used as an interaction source |
+| Tab | Tab | The tab a widget switches to |
+| Add mapping | Zuordnung hinzufügen | Add a layer group → tab pair |
+| Source layer | Quell-Layer | The layer whose visibility is watched |
+| Target layers | Ziel-Layer | Layers that mirror the source layer's visibility |
+| Add target layer | Ziel-Layer hinzufügen | Add a target layer to sync |
 
 ## Expression & Formula Builder
 

--- a/apps/docs/docs/sharing/sharing.md
+++ b/apps/docs/docs/sharing/sharing.md
@@ -49,7 +49,7 @@ When you share a dataset/project with a Team/Organization, all members will have
 
 ---
 
-## Managing access to a Dataset or Project
+## Managing access to a Dataset, Project, or Folder
 
 <div class="step">
    <div class="step-number">1</div>
@@ -74,6 +74,27 @@ When you share a dataset/project with a Team/Organization, all members will have
    <div class="step-number">4</div>
    <div class="content">If you want to withdraw access, click the <code>More options</code> <img src={require('/img/icons/3dots.png').default} alt="More options" style={{ maxHeight: '20px', maxWidth: '20px'}}/> menu on your dataset or project and select <code>no access</code>.</div>
 </div>
+
+### Sharing a Folder
+
+You can also share an entire **folder** at once. Sharing a folder grants access to **all datasets and projects inside it**, so you don't have to share each item individually.
+
+<div class="step">
+   <div class="step-number">1</div>
+   <div class="content">Click the <code>More options</code> <img src={require('/img/icons/3dots.png').default} alt="More options" style={{ maxHeight: '20px', maxWidth: '20px'}}/> menu on a folder you own and select <code>Share</code>.</div>
+</div>
+<div class="step">
+   <div class="step-number">2</div>
+   <div class="content">Choose an <code>Organization</code> or <code>Team</code> and grant <code>viewer</code> or <code>editor</code> access as needed.</div>
+</div>
+<div class="step">
+   <div class="step-number">3</div>
+   <div class="content">To withdraw access, open the <code>Share</code> dialog again and set the role back to <code>no access</code>.</div>
+</div>
+
+:::info
+A folder can be shared with **either one Organization or one Team, not both at the same time**. Items inside a shared folder inherit the folder's access, so sharing them individually is not needed.
+:::
 
 ### Accessing Shared Items
 

--- a/apps/docs/docs/toolbox/accessibility_indicators/pt_trip_count.md
+++ b/apps/docs/docs/toolbox/accessibility_indicators/pt_trip_count.md
@@ -4,7 +4,7 @@ sidebar_position: 8
 
 # Trip Count Platform
 
-This indicator displays the **average number of public transport departures** per hour for each public transport stop.
+This indicator displays the **average number of public transport departures** per hour for each public transport platform.
 
 <div style={{ display: 'flex', justifyContent: 'center' }}>
 <iframe width="560" height="315" src="https://www.youtube.com/embed/2oRxWow9LBQ?si=IYvAqZcpSO02yDaA&amp;start=46" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
@@ -12,7 +12,7 @@ This indicator displays the **average number of public transport departures** pe
 
 ## 1. Explanation
 
-The **Trip Count Platform** shows the **average number of departures per hour for a selected time interval at each public transport stop**. You can view the sum for all modes or focus on a specific mode (e.g., bus, tram, metro, rail).
+The **Trip Count Platform** shows the **average number of departures per hour for a selected time interval at each public transport platform**. You can view the sum for all modes or focus on a specific mode (e.g., bus, tram, metro, rail).
 
 This indicator is the foundation for the [ÖV-Güteklassen](./oev_gueteklassen.md) and is useful for **weak point analyses of local transport plans** (see, among others, [Guideline for Local Transport Planning in Bavaria](https://www.demografie-leitfaden-bayern.de/index.html)).
 
@@ -69,9 +69,9 @@ Trip Count Platform computation is available for areas where public transport GT
 
 ### Results
 
-When the calculation is finished, a new layer called <b>"Trip Count Station"</b> will be added to the map.
+When the calculation is finished, a new layer called <b>"Trip Count Platform"</b> will be added to the map.
 
-Click on stations to view details including **station name**, **total departure count**, and **departure counts per mode**.
+Click on platforms to view details including **platform name**, **total departure count**, and **departure counts per mode**.
 
 <div style={{ display: 'flex', justifyContent: 'center' }}>
 

--- a/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/builder/settings.md
+++ b/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/builder/settings.md
@@ -70,7 +70,49 @@ Legen Sie fest, wie Ihr Dashboard beim Teilen in sozialen Medien oder Messenger-
 
 ## Interaktionen
 
-Klicken Sie auf `Interaktionen verwalten`, um den Interaktionseditor zu öffnen. Interaktionen verknüpfen Dashboard-Elemente miteinander — zum Beispiel kann das Klicken auf eine Layer-Gruppe den aktiven Tab in einem Widget wechseln. Klicken Sie auf `Interaktion hinzufügen`, um eine neue Interaktion zu erstellen.
+Interaktionen verknüpfen Dashboard-Elemente miteinander, sodass eine Aktion des Betrachters automatisch eine passende Änderung an einem anderen Element auslöst. Zum Beispiel kann das Aktivieren einer Layer-Gruppe den aktiven Tab in einem Widget wechseln, oder das Ein- und Ausblenden eines Layers kann zugehörige Layer ebenfalls anzeigen und ausblenden.
+
+Klicken Sie auf `Interaktionen verwalten`, um den Interaktionseditor zu öffnen. Jede Interaktion ist eine Regel aus einem **Auslöser** (`Wenn` etwas passiert) und einer **Aktion** (was daraufhin geschieht). Klicken Sie auf `Interaktion hinzufügen`, um eine neue Regel zu erstellen, und wählen Sie anschließend den Auslöser unter `Wenn`. Mit dem Schalter `Aktiviert` können Sie eine einzelne Interaktion ein- oder ausschalten, ohne sie zu löschen.
+
+GOAT unterstützt zwei Arten von Interaktionen:
+
+### Layer-Gruppe aktiviert → Tab wechseln
+
+Wenn ein Betrachter eine Layer-Gruppe aktiviert, wechselt ein Tabs-Widget zu einem von Ihnen gewählten Tab.
+
+<div class="step">
+  <div class="step-number">1</div>
+  <div class="content">Setzen Sie <code>Wenn</code> auf <code>Layer-Gruppe aktiviert</code>.</div>
+</div>
+
+<div class="step">
+  <div class="step-number">2</div>
+  <div class="content">Wählen Sie das <code>Ziel-Widget</code> — das Tabs-Widget, dessen aktiver Tab gewechselt werden soll.</div>
+</div>
+
+<div class="step">
+  <div class="step-number">3</div>
+  <div class="content">Ordnen Sie unter <code>Layer-Gruppe</code> und <code>Tab</code> jeder Layer-Gruppe den Tab zu, der geöffnet werden soll. Klicken Sie auf <code>Zuordnung hinzufügen</code>, um weitere Paare hinzuzufügen.</div>
+</div>
+
+### Layer-Sichtbarkeit geändert → Sichtbarkeit synchronisieren
+
+Wenn ein Betrachter einen Layer ein- oder ausblendet, werden ein oder mehrere andere Layer entsprechend ein- oder ausgeblendet.
+
+<div class="step">
+  <div class="step-number">1</div>
+  <div class="content">Setzen Sie <code>Wenn</code> auf <code>Layer-Sichtbarkeit geändert</code>.</div>
+</div>
+
+<div class="step">
+  <div class="step-number">2</div>
+  <div class="content">Wählen Sie den <code>Quell-Layer</code> — den Layer, dessen Sichtbarkeit überwacht wird.</div>
+</div>
+
+<div class="step">
+  <div class="step-number">3</div>
+  <div class="content">Fügen Sie einen oder mehrere <code>Ziel-Layer</code> hinzu, welche die Sichtbarkeit des Quell-Layers übernehmen sollen. Klicken Sie auf <code>Ziel-Layer hinzufügen</code>, um weitere hinzuzufügen.</div>
+</div>
 
 ---
 

--- a/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/map/filter.md
+++ b/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/map/filter.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 # Filter
 
 
-**Filter begrenzt die Datensichtbarkeit auf Ihrer Karte** durch logische Ausdrücke (z.B. Supermärkte mit bestimmten Namen) oder räumliche Ausdrücke (z.B. Punkte innerhalb eines Begrenzungsrahmens). **Das Filter-Tool ermöglicht es Ihnen, sich auf relevante Informationen zu konzentrieren, ohne die ursprünglichen Daten zu verändern.** Es funktioniert mit **Punkt-Layern** und **Polygon-Layern**, die `Zahlen` und `String`-Datentypen enthalten.
+**Filter begrenzt die Datensichtbarkeit auf Ihrer Karte** durch logische Ausdrücke (z.B. Supermärkte mit bestimmten Namen) oder räumliche Ausdrücke (z.B. Punkte innerhalb eines Begrenzungsrahmens). **Das Filter-Tool ermöglicht es Ihnen, sich auf relevante Informationen zu konzentrieren, ohne die ursprünglichen Daten zu verändern.** Es funktioniert mit **Punkt-Layern** und **Polygon-Layern**, die `Zahlen`-, `String`-, `Datum`- und `Boolean`-Datentypen enthalten.
 
 <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
 
@@ -51,7 +51,7 @@ import TabItem from '@theme/TabItem';
 
 <div class="step">
   <div class="step-number">6</div>
-  <div class="content">Wählen Sie den <code>Operator</code>. Verfügbare Optionen variieren je nach Datentyp: Zahl und String.</div>
+  <div class="content">Wählen Sie den <code>Operator</code>. Verfügbare Optionen variieren je nach Datentyp (<code>Zahl</code>, <code>String</code>, <code>Datum</code> und <code>Boolean</code>).</div>
 </div>
 
 <div style={{ display: 'flex', justifyContent: 'center' }}>
@@ -62,6 +62,8 @@ import TabItem from '@theme/TabItem';
 | ist nicht            | ist nicht              |
 | enthält              | enthält                |
 | schließt aus         | schließt aus           |
+| ist leer             | ist leer               |
+| ist nicht leer       | ist nicht leer         |
 | ist mindestens       | beginnt mit            |
 | ist weniger als      | endet mit              |
 | ist höchstens        | enthält den Text       |
@@ -70,6 +72,25 @@ import TabItem from '@theme/TabItem';
 |                      | ist kein leerer String |
 
 </div>
+
+<div style={{ display: 'flex', justifyContent: 'center' }}>
+
+| Ausdrücke für `Datum` | Ausdrücke für `Boolean` |
+| --------------------- | ----------------------- |
+| ist am                | ist wahr                |
+| ist nicht am          | ist falsch              |
+| ist vorher            | ist leer                |
+| ist danach            | ist nicht leer          |
+| im letzten            |                         |
+| nicht im letzten      |                         |
+| liegt zwischen        |                         |
+| liegt nicht dazwischen |                        |
+
+</div>
+
+:::tip Hinweis
+Bei `Datum`-Feldern wählen Sie ein Datum über den **Datumsauswähler**. **"liegt zwischen"** verwendet zwei Daten (**Von** und **Bis**), und **"im letzten"** erwartet eine **Anzahl von Tagen**. Bei `Boolean`-Feldern legt der Operator die Bedingung bereits fest, sodass kein Wert erforderlich ist.
+:::
 
 :::tip Hinweis
 Für die Ausdrücke **"enthält"** und **"schließt aus"** können mehrere Werte ausgewählt werden.

--- a/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/map/layer_editing.md
+++ b/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/map/layer_editing.md
@@ -44,7 +44,7 @@ Sobald der Layer erstellt wurde, können Sie Features direkt auf der Karte hinzu
 
 ## Daten ansehen
 
-**Daten ansehen** ermöglicht es Ihnen, Ihre Layer-Daten als Tabelle anzuzeigen und zu bearbeiten. Öffnen Sie die Ansicht über das <code>Weitere Optionen</code>-Menü des Layers, um Felder zu verwalten, Attributwerte direkt in der Tabelle zu bearbeiten oder den Bearbeitungsmodus zu starten.
+**Daten ansehen** ermöglicht es Ihnen, Ihre Layer-Daten als Tabelle anzuzeigen und zu bearbeiten. Öffnen Sie die Ansicht über das <img src={require('/img/icons/3dots.png').default} alt="Optionen" style={{ maxHeight: "20px", maxWidth: "20px", objectFit: "cover"}}/> <code>Weitere Optionen</code>-Menü des Layers, um Felder zu verwalten, Attributwerte direkt in der Tabelle zu bearbeiten oder den Bearbeitungsmodus zu starten.
 
 <div class="step">
   <div class="step-number">1</div>
@@ -53,10 +53,40 @@ Sobald der Layer erstellt wurde, können Sie Features direkt auf der Karte hinzu
 
 <div class="step">
   <div class="step-number">2</div>
-  <div class="content">Klicken Sie auf <code>+ Feld hinzufügen</code>, um den Dialog <b>Felder bearbeiten</b> zu öffnen. Fügen Sie ein neues Feld hinzu, indem Sie einen <b>Feldnamen</b> eingeben und den <b>Feldtyp</b> auswählen. Um ein Feld zu entfernen, klicken Sie auf das <code>—</code>-Symbol daneben. Klicken Sie auf <code>Speichern</code>, wenn Sie fertig sind.</div>
+  <div class="content">Klicken Sie in der Tabellen-Symbolleiste auf <code>Felder bearbeiten</code>, um den Dialog <b>Felder bearbeiten</b> zu öffnen, und klicken Sie dann auf <code>+ Feld hinzufügen</code>. Ein neues Feld wird der Liste hinzugefügt — wählen Sie rechts seinen <b>Feldtyp</b> (<code>Text</code>, <code>Number</code>, <code>Date</code>, <code>Boolean</code> oder <code>Formula</code>, ein berechnetes Feld, siehe <a href="#formelfelder">Formelfelder</a> unten) und benennen Sie das Feld in der Liste um. Um ein Feld zu entfernen, klicken Sie auf das <code>—</code>-Symbol daneben. Klicken Sie auf <code>Speichern</code>, wenn Sie fertig sind.</div>
 </div>
 
 <div class="step">
   <div class="step-number">3</div>
   <div class="content">Klicken Sie auf <code>Features bearbeiten</code> in der Tabellen-Leiste, um den Bearbeitungsmodus zu aktivieren. Sie können <strong>direkt auf eine Zelle klicken</strong>, um Attributwerte inline zu bearbeiten, den <strong>Auswahl-Cursor</strong> auf der Karte verwenden, um ein vorhandenes Feature auszuwählen und dessen Attribute im Panel <b>Feature-Attribute</b> zu aktualisieren, oder <code>+</code> nutzen, um ein neues Feature zu zeichnen. Klicken Sie auf <code>Speichern</code> oder <code>Verwerfen</code>, wenn Sie fertig sind.</div>
 </div>
+
+### Formelfelder
+
+Der Wert eines <b>Formula</b>-Felds wird aus einem Ausdruck berechnet, den Sie schreiben — ähnlich wie eine Formelspalte in einer Tabellenkalkulation. Der Ausdruck kann Ihre anderen Felder referenzieren — teilen Sie zum Beispiel die Bevölkerung durch die Fläche, um die Dichte zu erhalten — oder Textfelder zusammenführen. Das Ergebnis wird auf jedes Feature im Layer angewendet.
+
+<div class="step">
+  <div class="step-number">1</div>
+  <div class="content">Klicken Sie auf <code>Felder bearbeiten</code>, um den Dialog <b>Felder bearbeiten</b> zu öffnen, klicken Sie auf <code>+ Feld hinzufügen</code>, und setzen Sie bei ausgewähltem neuen Feld rechts seinen <code>Feldtyp</code> auf <code>Formula</code> (und benennen Sie das Feld in der Liste um).</div>
+</div>
+
+<div class="step">
+  <div class="step-number">2</div>
+  <div class="content">Klicken Sie auf <code>Formel hinzufügen</code>, um den <b>Formel-Editor</b> zu öffnen. Schreiben Sie einen Ausdruck und referenzieren Sie Ihre anderen Felder über ihren Namen in doppelten Anführungszeichen (zum Beispiel <code>"population"</code>). Über den Tab <b>Aufbau</b> können Sie Felder, Operatoren und Funktionen einfügen, und der Tab <b>Vorschau</b> zeigt ein Beispielergebnis. Ein grünes Häkchen bestätigt, dass der Ausdruck gültig ist.</div>
+</div>
+
+<div class="step">
+  <div class="step-number">3</div>
+  <div class="content">Klicken Sie auf <code>Anwenden</code> und anschließend im Dialog „Felder bearbeiten" auf <code>Speichern</code>. GOAT berechnet die Werte für alle Features und hält sie automatisch aktuell.</div>
+</div>
+
+**Beispiele:**
+
+- <code>"population" / "area_km2"</code> — Bevölkerungsdichte
+- <code>round("population" / "area_km2", 1)</code> — Dichte auf eine Nachkommastelle gerundet
+- <code>concat_ws(', ', "city", "country")</code> — Textfelder zusammenführen (z. B. `Berlin, Germany`)
+- <code>if("population" &gt; 100000, 'large', 'small')</code> — nach einem Schwellenwert klassifizieren
+
+:::info
+Die Werte einer Formel werden automatisch aktualisiert, wenn sich die referenzierten Felder ändern. Eine Formel muss einen Zahlen-, Text-, Wahr/Falsch- oder Datumswert ergeben. Formelfelder sind nur für bereits vorhandene Layer verfügbar.
+:::

--- a/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/sharing/sharing.md
+++ b/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/sharing/sharing.md
@@ -47,11 +47,11 @@ Wenn Sie einen Datensatz/ein Projekt mit einem Team oder einer Organisation teil
 
 ---
 
-## Zugriff auf einen Datensatz oder ein Projekt verwalten
+## Zugriff auf einen Datensatz, ein Projekt oder einen Ordner verwalten
 
 <div class="step">
    <div class="step-number">1</div>
-   <div class="content">Klicken Sie auf das <code>Mehr Optionen</code>-Menü <img src={require('/img/icons/3dots.png').default} alt="Mehr Optionen" style={{ maxHeight: '20px', maxWidth: '20px'}}/> bei Ihrem Datensatz oder Projekt.</div>
+   <div class="content">Klicken Sie bei Ihrem Datensatz oder Projekt auf <code>Mehr Optionen</code> <img src={require('/img/icons/3dots.png').default} alt="Mehr Optionen" style={{ maxHeight: '20px', maxWidth: '20px'}}/>.</div>
 </div>
 <div class="step">
    <div class="step-number">2</div>
@@ -69,8 +69,29 @@ Wenn Sie einen Datensatz/ein Projekt mit einem Team oder einer Organisation teil
 
 <div class="step">
    <div class="step-number">4</div>
-   <div class="content">Wenn Sie den Zugriff entziehen möchten, klicken Sie auf das <code>Mehr Optionen</code>-Menü <img src={require('/img/icons/3dots.png').default} alt="Mehr Optionen" style={{ maxHeight: '20px', maxWidth: '20px'}}/> und wählen Sie <code>Kein Zugriff</code>.</div>
+   <div class="content">Wenn Sie den Zugriff entziehen möchten, klicken Sie auf <code>Mehr Optionen</code> <img src={require('/img/icons/3dots.png').default} alt="Mehr Optionen" style={{ maxHeight: '20px', maxWidth: '20px'}}/> und wählen Sie <code>Kein Zugriff</code>.</div>
 </div>
+
+### Einen Ordner teilen
+
+Sie können auch einen ganzen **Ordner** auf einmal teilen. Das Teilen eines Ordners gewährt Zugriff auf **alle darin enthaltenen Datensätze und Projekte**, sodass Sie nicht jedes Element einzeln teilen müssen.
+
+<div class="step">
+   <div class="step-number">1</div>
+   <div class="content">Klicken Sie bei einem Ordner, den Sie besitzen, auf <code>Mehr Optionen</code> <img src={require('/img/icons/3dots.png').default} alt="Mehr Optionen" style={{ maxHeight: '20px', maxWidth: '20px'}}/> und wählen Sie <code>Teilen</code>.</div>
+</div>
+<div class="step">
+   <div class="step-number">2</div>
+   <div class="content">Wählen Sie eine <code>Organisation</code> oder ein <code>Team</code> und gewähren Sie <code>Viewer</code>- oder <code>Editor</code>-Zugriff nach Bedarf.</div>
+</div>
+<div class="step">
+   <div class="step-number">3</div>
+   <div class="content">Um den Zugriff zu entziehen, öffnen Sie den <code>Teilen</code>-Dialog erneut und setzen Sie die Rolle zurück auf <code>Kein Zugriff</code>.</div>
+</div>
+
+:::info
+Ein Ordner kann **entweder mit einer Organisation oder mit einem Team geteilt werden, nicht mit beiden gleichzeitig**. Elemente in einem geteilten Ordner erben den Zugriff des Ordners, sodass ein individuelles Teilen nicht erforderlich ist.
+:::
 
 ### Geteilte Elemente aufrufen
 

--- a/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/toolbox/accessibility_indicators/pt_trip_count.md
+++ b/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/toolbox/accessibility_indicators/pt_trip_count.md
@@ -3,9 +3,9 @@ sidebar_position: 8
 ---
 
 
-# Anzahl Abfahrten
+# Anzahl Abfahrten Haltepunkte
 
-Dieser Indikator zeigt die **durchschnittliche Anzahl der Abfahrten öffentlicher Verkehrsmittel** pro Stunde für jede Haltestelle des öffentlichen Verkehrs an.
+Dieser Indikator zeigt die **durchschnittliche Anzahl der Abfahrten öffentlicher Verkehrsmittel** pro Stunde für jeden Haltepunkt des öffentlichen Verkehrs an.
 
 <div style={{ display: 'flex', justifyContent: 'center' }}>
 <iframe  width="674" height="378" src="https://www.youtube.com/embed/psnuUksG7W4?si=dhLw5Gp0ThYHFd5l&amp;start=46" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
@@ -13,7 +13,7 @@ Dieser Indikator zeigt die **durchschnittliche Anzahl der Abfahrten öffentliche
 
 ## 1. Erklärung
 
-**Anzahl Abfahrten** zeigt die **durchschnittliche Anzahl der Abfahrten pro Stunde für ein ausgewähltes Zeitintervall an jeder Haltestelle des öffentlichen Verkehrs**. Sie können die Summe für alle Verkehrsmittel anzeigen oder sich auf ein bestimmtes Verkehrsmittel konzentrieren (z.B. Bus, Straßenbahn, U-Bahn, Bahn).
+**Anzahl Abfahrten Haltepunkte** zeigt die **durchschnittliche Anzahl der Abfahrten pro Stunde für ein ausgewähltes Zeitintervall an jedem Haltepunkt des öffentlichen Verkehrs**. Sie können die Summe für alle Verkehrsmittel anzeigen oder sich auf ein bestimmtes Verkehrsmittel konzentrieren (z.B. Bus, Straßenbahn, U-Bahn, Bahn).
 
 Dieser Indikator ist die Grundlage für die [ÖV-Güteklassen](./oev_gueteklassen.md) und ist nützlich für **Schwachstellenanalysen von lokalen Verkehrsplänen** (siehe unter anderem [Richtlinie für die Nahverkehrsplanung in Bayern](https://www.demografie-leitfaden-bayern.de/index.html)).
 
@@ -38,7 +38,7 @@ Die Berechnung der Anzahl Abfahrten ist für Gebiete verfügbar, in denen GTFS-D
 
 <div class="step">
   <div class="step-number">2</div>
-  <div class="content">Unter <code>Erreichbarkeitsindikatoren</code> wählen Sie <code>Anzahl Abfahrten</code>, um das Einstellungsmenü zu öffnen.</div>
+  <div class="content">Unter <code>Erreichbarkeitsindikatoren</code> wählen Sie <code>Anzahl Abfahrten Haltepunkte</code>, um das Einstellungsmenü zu öffnen.</div>
 </div>
 
 ### Berechnungszeit
@@ -69,9 +69,9 @@ Die Berechnung der Anzahl Abfahrten ist für Gebiete verfügbar, in denen GTFS-D
 
 ### Ergebnisse
 
-Nach Abschluss der Berechnung wird ein neuer Layer namens <b>"Trip Count Station"</b> zur Karte hinzugefügt.
+Nach Abschluss der Berechnung wird ein neuer Layer namens <b>"Anzahl Abfahrten Haltepunkte"</b> zur Karte hinzugefügt.
 
-Klicken Sie auf Stationen, um Details anzuzeigen, einschließlich **Stationsname**, **Gesamtanzahl der Abfahrten** und **Abfahrten pro Verkehrsmittel**.
+Klicken Sie auf Haltepunkte, um Details anzuzeigen, einschließlich **Name des Haltepunkts**, **Gesamtanzahl der Abfahrten** und **Abfahrten pro Verkehrsmittel**.
 
 
 


### PR DESCRIPTION
## Description
Documentation updates (English + German) for several features that shipped recently but were not yet documented:

- **Trip Count Platform** — clarify that departures are counted at the **platform** level (not station level).
- **Dashboard Interactions** — expand the Builder → Settings "Interactions" section: explain the trigger/action model and add setup steps for both interaction types (Layer group activated → Switch tab, Layer visibility changed → Sync visibility). Added matching glossary entries.
- **Folder sharing** — document sharing a whole folder; renamed the section to "Managing access to a Dataset, Project, or Folder".
- **Formula field type** — document the new Formula computed-field kind on the Layer Editing page (Formula Builder, referencing other fields, examples).
- **Datetime & boolean filters** — add datetime and boolean operators to the Filter page's logical-expression section, plus the missing "is blank / is not blank" operators for number and string.

## Motivation and Context
These features are live but the docs lagged behind. Each change was verified against the current code and the exact UI labels in both locales.

## How Has This Been Tested?
Documentation-only change — no application code affected. Wording and UI labels were checked against the corresponding components and i18n strings (EN + DE).

## Screenshots (if appropriate):
N/A — documentation only.

## Related Issue
N/A
